### PR TITLE
add try/except for validation errors in delete model mixin

### DIFF
--- a/resticus/mixins.py
+++ b/resticus/mixins.py
@@ -1,3 +1,5 @@
+from django.core.exceptions import ValidationError
+
 from . import http
 from .utils import patch_form
 
@@ -82,5 +84,8 @@ class PatchModelMixin(object):
 class DeleteModelMixin(object):
     def delete(self, request, *args, **kwargs):
         self.object = self.get_object()
-        self.object.delete()
+        try:
+            self.object.delete()
+        except ValidationError as err:
+            return http.Http400(err.message)
         return http.Http204()


### PR DESCRIPTION
If a deleting a model throws a validation error, pass on the error message and return Http400.