### PR TITLE
add try/except to handle http404 exception in detailModelMixin

### DIFF
--- a/resticus/mixins.py
+++ b/resticus/mixins.py
@@ -1,3 +1,5 @@
+from django.http import Http404
+
 from . import http
 from .utils import patch_form
 
@@ -30,7 +32,10 @@ class ListModelMixin(object):
 
 class DetailModelMixin(object):
     def get(self, request, *args, **kwargs):
-        self.object = self.get_object()
+        try:
+            self.object = self.get_object()
+        except Http404:
+            return http.Http404()
         return {'data': self.serialize(self.object)}
 
 


### PR DESCRIPTION
Adding a handler for Http404 when object is not found in DetailModelMixin, in the case when we want to use `get_object_or_404` on a view.