### PR TITLE
Manual filtering

### DIFF
--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -185,4 +185,3 @@ class TestSerialization(TestCase):
             filter=lambda book: int(book.isbn.split('-')[-1]) < 5
         )
         assert len(s) == 5
-

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -177,3 +177,12 @@ class TestSerialization(TestCase):
             include=[('desc', accessor)])
 
         self.assertEqual(runs[0], 2)
+
+    def test_filtering(self):
+        s = serialize(
+            self.books,
+            fields=('id', 'isbn'),
+            filter=lambda book: int(book.isbn.split('-')[-1]) < 5
+        )
+        assert len(s) == 5
+


### PR DESCRIPTION
Add a way to manually filter serialized objects before they've been serialized. This is helpful for when the filtering is complex and doesn't lend itself well to being done easily in the ORM/SQL.