### PR TITLE
Add support for tracking/handling errors.

### DIFF
--- a/resticus/settings.py
+++ b/resticus/settings.py
@@ -11,6 +11,7 @@ DEFAULTS = {
         "resticus.auth.BasicHttpAuth",
     ),
     "DEFAULT_PERMISSION_CLASSES": ("resticus.permissions.AllowAny",),
+    "ERROR_HANDLER": None,
     "JSON_DECODER": "resticus.encoders.JSONDecoder",
     "JSON_ENCODER": "resticus.encoders.JSONEncoder",
     "LOGIN_REQUIRED": False,
@@ -35,6 +36,7 @@ IMPORT_STRINGS = (
     "JSON_DECODER",
     "JSON_ENCODER",
     "DATA_PARSERS",
+    "ERROR_HANDLER",
 )
 
 

--- a/resticus/views.py
+++ b/resticus/views.py
@@ -197,8 +197,14 @@ class Endpoint(View):
 
     def server_error(self, err):
         if settings.DEBUG:
-            return http.Http500(str(err))
-        return http.Http500(_("Internal server error."))
+            response = http.Http500(str(err))
+        else:
+            response = http.Http500(_("Internal server error."))
+
+        if api_settings.ERROR_HANDLER is not None:
+            api_settings.ERROR_HANDLER(self, err, response)
+
+        return response
 
     def api_exception(self, err):
         return err.response

--- a/tests/handlers.py
+++ b/tests/handlers.py
@@ -1,0 +1,6 @@
+
+
+def track_errors(view, error, response):
+    # Send the error to an application
+    # monitoring service, e.g., Sentry
+    response.error_tracked = True

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -88,5 +88,6 @@ STATIC_URL = '/static/'
 RESTICUS = {
     'DEFAULT_AUTHENTICATION_CLASSES': (),
     'LOGIN_REQUIRED': False,
-    'TOKEN_MODEL': 'resticus.Token'
+    'TOKEN_MODEL': 'resticus.Token',
+    'ERROR_HANDLER': 'tests.handlers.track_errors',
 }

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -107,6 +107,7 @@ class TestEndpoint(TestCase):
         r = self.client.get('fail_view')
         self.assertEqual(r.status_code, 500)
         self.assertEqual(r.json['errors']['detail'][0]['message'], "Internal server error.")
+        self.assertTrue(r.error_tracked)
 
     def test_raw_request_body(self):
         raw = b'\x01\x02\x03'


### PR DESCRIPTION
This PR adds a new setting, `ERROR_HANDLER`, which is a Python path to a function that will be called for any undefined server errors. The error handling must be a callable that accepts two arguments, `view` and `error`. This is useful for sending application errors to a monitoring service like Sentry.