### PR TITLE
Allow streaming to be configured for base view classes by settings.

### DIFF
--- a/resticus/mixins.py
+++ b/resticus/mixins.py
@@ -11,8 +11,6 @@ __all__ = [
 
 
 class ListModelMixin(object):
-    streaming = True
-
     def get(self, request, *args, **kwargs):
         """
         Returns a list of objects.

--- a/resticus/settings.py
+++ b/resticus/settings.py
@@ -22,6 +22,12 @@ DEFAULTS = {
         "multipart/form-data": "resticus.parsers.parse_multipart",
         "text/plain": "resticus.parsers.parse_plain_text",
     },
+
+    # List of view class names that will stream the JSON response
+    'STREAMING': [
+        'resticus.mixins.ListModelMixin',
+    ],
+
     # Pagination
     "PAGINATE": True,
     "PAGE_SIZE": 100,


### PR DESCRIPTION
This PR allows which views return streaming responses to be configured in the `RESTICUS` settings by adding the direct class or one of it's MRO's to the `STREAMING` list.